### PR TITLE
deactivates the pupil signup for selected chapters

### DIFF
--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -68,6 +68,7 @@ const chapters_query = `{
       }
       baseId
       acceptsSignups
+      deactivatePupils
       token
     }
   }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -7,6 +7,7 @@ export type Chapter = {
   }
   baseId: string
   acceptsSignups: boolean
+  deactivatePupils: boolean
   token: string
 }
 
@@ -62,7 +63,7 @@ export const BlogTags = [
   `Auszeichnung`,
 ] as const // use const assertion to turn BlogTags into readonly tuple
 
-export type BlogTag = (typeof BlogTags)[number]
+export type BlogTag = typeof BlogTags[number]
 
 export type Post = Page & {
   author: Author

--- a/src/routes/signup-pupil/+page.server.ts
+++ b/src/routes/signup-pupil/+page.server.ts
@@ -10,6 +10,7 @@ import raw_form from '../../signup-form/de/pupil.yml'
 export const load: PageServerLoad = async () => {
   let chapters = await fetch_chapters()
   chapters = chapters.filter((chap) => chap.acceptsSignups)
+  chapters = chapters.filter((chap) => !chap.deactivatePupils)
 
   const form = parse_form_data({ ...raw_form, ...messages })
 

--- a/src/routes/standorte/[slug]/+page.svelte
+++ b/src/routes/standorte/[slug]/+page.svelte
@@ -13,7 +13,7 @@
 <BasePage {page}>
   <!-- Buttons at the end of the chapter pages to contact the dfferent chapter manager by mail
   showSignupButtons should be set false when chapter is still in setup -->
-  {#if page?.yaml?.showSignupButtons !== false}
+  {#if page?.yaml?.showSignupButtons !== false && page?.yaml?.allowPupils !== false}
     <h2 style="text-align: center; margin-top: 2em;">{$microcopy?.location?.register}</h2>
     <section>
       <span>
@@ -61,7 +61,56 @@
         >
       </span>
     </section>
+  {:else if page?.yaml?.allowPupils == false}
+    <h2 style="text-align: center; margin-top: 2em;">{$microcopy?.location?.register}</h2>
+    <section>
+      <span>
+        {$microcopy?.location?.joinStudent}
+        <a href="/signup-student?chapter={page.title}" class="btn blue">
+          <Icon inline icon="fa-solid:graduation-cap" {style} />{$microcopy?.location
+            ?.registerStudent}
+        </a>
+        <a href={$microcopy?.location?.linkStudentInfo} class="btn blue stroke">
+          <Icon
+            inline
+            icon="bi:info-circle-fill"
+            style={style + `margin-right: 6pt;`}
+          />{$microcopy?.location?.infoStudentButton}
+        </a>
+      </span>
+      <span>
+        {$microcopy?.location?.joinPupil}
+        <a class="btn green">
+          <Icon inline icon="fa-solid:child" {style} />{$microcopy?.location
+            ?.declinePupil}
+        </a>
+        <a href={$microcopy?.location?.linkPupilInfo} class="btn green stroke">
+          <Icon
+            inline
+            icon="bi:info-circle-fill"
+            style={style + `margin-right: 6pt;`}
+          />{$microcopy?.location?.infoPupilButton}</a
+        >
+      </span>
+      <span>
+        {$microcopy?.location?.locationManagement}
+        <a
+          href="mailto:info.{slug}{$microcopy?.location?.mailTo} {page.title}"
+          class="btn orange"
+        >
+          <Icon inline icon="ic:email" {style} />{$microcopy?.location?.writeMailButton}
+        </a>
+        <a href={$microcopy?.location?.linkLeadingInfo} class="btn orange stroke">
+          <Icon
+            inline
+            icon="bi:info-circle-fill"
+            style={style + `margin-right: 6pt;`}
+          />{$microcopy?.location?.infoLeadingButton}</a
+        >
+      </span>
+    </section>
   {/if}
+
 
   <svelte:fragment slot="afterBody">
     {#if page?.yaml?.showSignupButtons !== false}


### PR DESCRIPTION
Some chapters want to deactivate the signup button

Still to do is a feedback for the user when they try to select the chapter in the signup form, that the waiting list for this chapter is full.